### PR TITLE
per FCS 3.1 standard, added three keywords denoting modification of F…

### DIFF
--- a/R/define_keywords.R
+++ b/R/define_keywords.R
@@ -6,6 +6,15 @@
 #' Updates FCS file keywords after unmixing to define the new parameters. Tracks
 #' existing keywords from the input FCS file for metadata compatibility.
 #'
+#' Per [Data File Standard for Flow Cytometry, version FCS 3.1](https://doi.org/10.1002/cyto.a.20825):
+#' \itemize{
+#'   \item $LAST_MODIFIED/dd-mmm-yyyy hh:mm:ss.cc
+#'   \item $LAST_MODIFIER/string/
+#'   \item $ORIGINALITY/string
+#' }
+#'
+#' are added as additional keywords to denote modification of the FCS file.
+#'
 #' @param fcs.keywords The input keywords obtained from the read FCS file.
 #' @param final.matrix The expression data, containing both unmixed data and any
 #' retained parameters such as scatter and time.
@@ -164,7 +173,10 @@ define.keywords <- function(
     "SPECTRA" = format.matrix.string(spectra),
     "FLUOROCHROMES" = paste(rownames(spectra), collapse = ","),
     "AUTOSPECTRAL" = asp.ver,
-    "AUTOSPECTRALRCPP" = rcpp.ver
+    "AUTOSPECTRALRCPP" = rcpp.ver,
+    '$LAST_MODIFIED' = toupper(format(Sys.time(), "%d-%b-%Y %H:%M:%OS2")),
+    '$LAST_MODIFIER' = sprintf("AutoSpectral_%s", utils::packageVersion("AutoSpectral")),
+    '$ORIGINALITY' = "DataModified"
   ))
 
   # add AF spectra if used

--- a/man/define.keywords.Rd
+++ b/man/define.keywords.Rd
@@ -52,4 +52,13 @@ The updated keyword list for writing the FCS file.
 \description{
 Updates FCS file keywords after unmixing to define the new parameters. Tracks
 existing keywords from the input FCS file for metadata compatibility.
+
+Per \href{https://doi.org/10.1002/cyto.a.20825}{Data File Standard for Flow Cytometry, version FCS 3.1}:
+\itemize{
+\item $LAST_MODIFIED/dd-mmm-yyyy hh:mm:ss.cc
+\item $LAST_MODIFIER/string/
+\item $ORIGINALITY/string
+}
+
+are added as additional keywords to denote modification of the FCS file.
 }


### PR DESCRIPTION
per FCS 3.1 standard, added three keywords denoting modification of FCS file;

see pages 18, 19

[Data File Standard for Flow Cytometry, Version FCS 3.1](https://pmc.ncbi.nlm.nih.gov/articles/instance/2892967/bin/NIHMS203250-supplement-Supp_Fig_1.pdf)